### PR TITLE
Add a .travis.yml using shellcheck to lint our files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+matrix:
+    fast_finish: true
+    allow_failures:
+        - env: SHELLCHECK_EXEMPTIONS=""
+
+before_install:
+    # Add my repository's PGP key. -GLolol
+    - sudo apt-key adv --keyserver pgp.mit.edu --recv-keys F953726C
+    - echo 'deb http://packages.overdrive.pw/ precise-backports main' | sudo tee --append /etc/apt/sources.list
+
+install:
+    - sudo apt-get update -q
+    - sudo apt-get install -y shellcheck
+
+env:
+    - SHELLCHECK_EXEMPTIONS=""
+    # SC2016: Expressions don't expand in single quotes, use double quotes for that.
+    #   False positive; here are times where we want to literally print '$PATH'.
+    # SC2086: Double quote to prevent globbing and word splitting.
+    #   Globs don't expand when quoted, which we need
+    - SHELLCHECK_EXEMPTIONS="-e 2016,2086"
+
+script:
+    - shellcheck $SHELLCHECK_EXEMPTIONS ./rlw
+
+sudo: required
+
+notifications:
+    email: false


### PR DESCRIPTION
Travis CI is a continuous integration platform that hooks onto Git commits and can automatically compile/test/do whatever with code as commits are pushed to a repository: http://docs.travis-ci.com/user/for-beginners/

In this case, I've added a `.travis.yml` (Travis configuration) file that automatically downloads and runs `shellcheck` on `rlw`, with (and without, for reference) the applicable exceptions to prevent false positives.

@alfonsojon I will have to enable Travis for this repository manually if this gets merged. Afterwards, results will be available at https://travis-ci.org/roblox-linux-wrapper/roblox-linux-wrapper. I've already [enabled it for my fork](https://travis-ci.org/GLolol/roblox-linux-wrapper) so you can see it in action.