### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ### As of March of 2020, this script does *not* work with the latest versions of Roblox Player
 
-This is because the game uses VMProtect anti cheat, which Wine causes it to detect tampering. No ETA for a fix is available. The only way for this to be fixed is if Wine upstream is able to support VMProtect to a high enough degree, or if Roblox themselves release a Linux build. The script itself will still install Roblox on Linux, but do not expect to be able to play online.
+~~This is because the game uses VMProtect anti cheat, which Wine causes it to detect tampering. No ETA for a fix is available. The only way for this to be fixed is if Wine upstream is able to support VMProtect to a high enough degree, or if Roblox themselves release a Linux build.~~ The script itself will still install Roblox on Linux, but do not expect to be able to play online.
+
+As of November, VMProtect is no longer the problem. The game launches and is playable for a few seconds before the client is kicked. Wine currently cannot solve the challenge packet sent by the server as an anticheat measure. The possibility of a fix still comes down to Wine's capability to handle this particular anticheat measure in the future, or the Roblox devs providing official support. 
 
 <hr>
 


### PR DESCRIPTION
The README currently has misinformation about the cause of Roblox's instability on Wine. It cites VMProtect as the primary issue, which is not the case as of November 2020.