### PR TITLE
#197 * Only use first find result for RobloxPlayerLauncher.exe

### DIFF
--- a/data/roblox-player.sh
+++ b/data/roblox-player.sh
@@ -15,4 +15,4 @@ else
     exit 1
 fi
 
-rwine "$(find "$HOME/.local/share/wineprefixes/roblox-wine" -name RobloxPlayerLauncher.exe)" "$1"
+rwine "$(find "$HOME/.local/share/wineprefixes/roblox-wine" -name RobloxPlayerLauncher.exe -print -quit)" "$1"

--- a/data/roblox-player.sh
+++ b/data/roblox-player.sh
@@ -15,4 +15,4 @@ else
     exit 1
 fi
 
-rwine "$(find "$HOME/.local/share/wineprefixes/roblox-wine" -name RobloxPlayerLauncher.exe -print -quit)" "$1"
+rwine "$(find "$WINEPREFIX" -name RobloxPlayerLauncher.exe -print -quit)" "$1"


### PR DESCRIPTION
Hi, I got the same error as described in #197.
After debugging the starter I noticed that the find command returned two lines and as a result the wine command was not able to execute the RobloxPlayerLauncher.exe in the right path.

Here is the output when executing the **roblox-player.sh** in terminal:
```
user@pc:~$ bash -c "$HOME/.rlw/handlers/roblox-player.sh %u"
Sourcing rlw-core.sh
> wineinitialize: sourcing /home/user/.rlw/wine_choice
> wineinitialize: source complete
> wineinitialize: wine path set to /usr/bin/wine
> wineinitialize: wineserver path set to /usr/bin/wineserver
> wineinitialize: Wine version wine-7.0 is installed
> rwine: calling wine with arguments "/home/user/.local/share/wineprefixes/roblox-wine/drive_c/Program Files/Roblox/Versions/version-d0768f1540634f05/RobloxPlayerLauncher.exe
/home/user/.local/share/wineprefixes/roblox-wine/drive_c/users/user/Temp/RBX-8F84B449/RobloxPlayerLauncher.exe %u "
MESA-INTEL: warning: Performance support disabled, consider sysctl dev.i915.perf_stream_paranoid=0

wine: failed to open "/home/user/.local/share/wineprefixes/roblox-wine/drive_c/Program Files/Roblox/Versions/version-d0768f1540634f05/RobloxPlayerLauncher.exe\n/home/user/.local/share/wineprefixes/roblox-wine/drive_c/users/user/Temp/RBX-8F84B449/RobloxPlayerLauncher.exe": c0000135
```

The fix is to exit the find command after the first result is found. An alternative would be to make a `| head -n 1` to only use the first output line.

Hope that also solves the issue for others.